### PR TITLE
Patches for building with OPAM with Dune on OCaml 4.07.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 all:
-	jbuilder build --dev
+	jbuilder build
 
 tests:
-	jbuilder runtest --dev
+	jbuilder runtest
 
 clean:
 	jbuilder clean

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,19 @@
 all:
-	jbuilder build
+	dune build
 
 tests:
-	jbuilder runtest
+	dune runtest
 
 clean:
-	jbuilder clean
+	dune clean
 
 indent:
 	ocp-indent -i src/*.ml
 	ocp-indent -i src/*.mli
 	ocp-indent -i samples/*.ml
-	jbuilder build --dev
+	dune build --dev
 
 utop:
-	jbuilder utop lib 
-
-#all-supported-ocaml-versions:
-#	$(JBUILDER) runtest --dev --workspace jbuild-workspace.dev
+	dune utop lib 
 
 .PHONY: all tests clean check indent-build utop

--- a/samples/dune
+++ b/samples/dune
@@ -1,0 +1,4 @@
+(executable
+ (name hello_scgi)
+ (modules hello_scgi)
+ (libraries scgi lwt.unix))

--- a/samples/hello_scgi.ml
+++ b/samples/hello_scgi.ml
@@ -8,7 +8,7 @@ open Lwt
 
 let () =
   (* Command line options *)
-  let port = ref 8080 in
+  let port = ref 1025 in
   let addr = ref "127.0.0.1" in
   let req_count = ref 0 in 
 

--- a/samples/jbuild
+++ b/samples/jbuild
@@ -1,6 +1,0 @@
-(jbuild_version 1)
-
-(executable
-    ((name hello_scgi)
-     (modules (hello_scgi))
-     (libraries (scgi lwt.unix))))

--- a/samples/jbuild
+++ b/samples/jbuild
@@ -2,4 +2,5 @@
 
 (executable
     ((name hello_scgi)
-    (libraries (scgi lwt.unix))))
+     (modules (hello_scgi))
+     (libraries (scgi lwt.unix))))

--- a/scgi.opam
+++ b/scgi.opam
@@ -12,7 +12,5 @@ build-test: [["jbuilder" "runtest" "-p" name]]
 depends : [
 	"jbuilder" {build}
 	"lwt"
-	"lwt_camlp4"
 	"uri"
-	"batteries"
 ] 

--- a/src/dune
+++ b/src/dune
@@ -1,0 +1,5 @@
+(library
+ (name scgi)
+ (public_name scgi)
+ (preprocess (pps lwt.ppx))
+ (libraries lwt.ppx uri lwt lwt.unix))

--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,5 @@
 (library
  (name scgi)
  (public_name scgi)
- (preprocess (pps lwt.ppx))
- (libraries lwt.ppx uri lwt lwt.unix))
+ (preprocess (pps lwt_ppx))
+ (libraries lwt_ppx uri lwt lwt.unix))

--- a/src/jbuild
+++ b/src/jbuild
@@ -4,4 +4,4 @@
 	((name scgi)
 	(public_name scgi)
 	(preprocess (pps (lwt.ppx)))
-	(libraries (lwt.ppx uri batteries lwt lwt.unix))))
+	(libraries (lwt.ppx uri lwt lwt.unix))))

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,7 +1,0 @@
-(jbuild_version 1)
-
-(library
-	((name scgi)
-	(public_name scgi)
-	(preprocess (pps (lwt.ppx)))
-	(libraries (lwt.ppx uri lwt lwt.unix))))


### PR DESCRIPTION
A few months ago, my colleague Paul started this branch to update the build the SCGI library with the latest OCaml 4.07.0 with OPAM 2. I admit I haven't re-built this in many weeks.

Can you review, test and integrate upstream?